### PR TITLE
Exit process on success

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,6 +69,7 @@ co(function *() {
 })
 .then(() => {
   console.log('All files uploaded.');
+  process.exit(0); // eslint-disable-line
 })
 .catch(err => {
   if (err.stack) {


### PR DESCRIPTION
Using this module within an npm task, it continues to hang after a successful deployment.

`package.json`
```
  ...
  "scripts": {
    "deploy": "s3-deploy \"./dist/**\" --cwd \"./dist/\" --bucket test"
  }
  ...
```