### PR TITLE
Fixed "s3-deploy" bug when it is used from windows machine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,16 @@ Invokes eslint validation based on rules defined in the `.eslintrc` file.
 
 ## Changelog
 
+### 0.6.1
+
+**Bug fix**
+
+- Fixing incorrect folder structure when `s3-deploy` is used from windows machine.
+
 ### 0.6.0
 
 ***API Additions**
-- Adding the ability to specify `filePrefix` 
+- Adding the ability to specify `filePrefix`
 
 ### 0.5.2
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3-deploy",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "NodeJS bash utility for deploying files to Amazon S3",
   "scripts": {
     "test": "mocha",

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -1,5 +1,6 @@
 import util from 'util';
 import path from 'path';
+import url from 'url';
 import zlib from 'zlib';
 
 import AWS from 'aws-sdk';
@@ -80,8 +81,8 @@ export const readFile = co.wrap(function *(filepath, cwd, gzipFiles) {
     return {
       stat: stat,
       contents: fileContents,
-      base: path.join(process.cwd(), cwd),
-      path: path.join(process.cwd(), filepath)
+      base: url.resolve(process.cwd(), cwd),
+      path: url.resolve(process.cwd(), filepath)
     };
   }
 


### PR DESCRIPTION
This Fork/PR fixes below issue:

While uploading the files to s3 bucket, the path.join statement in "readFile" function  uses '\' instead of '/' when s3-deploy command is executed from windows machine.

So the AWS considers the entire file path as a file name and uploads all files to the root directory of bucket instead of creating the folder structure. 

Due to this bug, none of our team members are able to deploy builds from Windows workstation.

Thanks,
Vish Patel
