### PR TITLE
Add profile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ You can also specify the `signatureVersion` that should be used by S3 client. Cu
 ```
 Use this parameter to specify a file prefix for all your destination files. For example, if you wanted to deploy a versioned history of your project to S3 whenever publishing to npm, you could use `--filePrefix $npm_package_version` in a script in your project's package.json file.
 
+```
+--profile
+```
+You can specify a specific AWS profile to use to connect to S3 (defaults to `default`). More information on how to setup AWS profiles is available in the [AWS docs](http://docs.aws.amazon.com/cli/latest/topic/config-vars.html).
+
 ## AWS Credentials
 AWS credentials can be provided via environment variables, or in the `~/.aws/credentials` file.  More details here:
 http://docs.aws.amazon.com/cli/latest/topic/config-vars.html. Please make sure to define a default in your AWS credentials, this will help prevent a `Missing Credentials` error during deployment.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3-deploy",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "NodeJS bash utility for deploying files to Amazon S3",
   "scripts": {
     "test": "mocha",

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -119,6 +119,12 @@ export const deploy = co.wrap(function *(files, options, AWSOptions, s3Options, 
   const cwd = options.cwd;
   const filePrefix = options.filePrefix || '';
 
+
+  if(options.profile) {
+    var credentials = new AWS.SharedIniFileCredentials({profile: options.profile});
+    AWS.config.credentials = credentials; 
+  }
+
   AWS.config.update(Object.assign({
     sslEnabled: true
   }, AWSOptions));

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ co(function *() {
     bucket: argv.bucket,
     region: argv.r || argv.region || 'us-east-1',
     cwd: argv.cwd || '',
-	  profile: argv.profile,    
+    profile: argv.profile,
     gzip: (argv.gzip ? 'gzip' : undefined),
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ co(function *() {
     bucket: argv.bucket,
     region: argv.r || argv.region || 'us-east-1',
     cwd: argv.cwd || '',
+	  profile: argv.profile,    
     gzip: (argv.gzip ? 'gzip' : undefined),
   };
 


### PR DESCRIPTION
Adds a `--profile` option that allows users to select which AWS profile should be used for the deployment (As per the [AWS documentation](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Using_Profiles_with_the_SDK)). If no profile is given, then the default profile is used.
