### PR TITLE
Promotes defining a default credential

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Use this parameter to specify a file prefix for all your destination files. For 
 
 ## AWS Credentials
 AWS credentials can be provided via environment variables, or in the `~/.aws/credentials` file.  More details here:
-http://docs.aws.amazon.com/cli/latest/topic/config-vars.html
+http://docs.aws.amazon.com/cli/latest/topic/config-vars.html. Please make sure to define a default in your AWS credentials, this will help prevent a `Missing Credentials` error during deployment.
 
 ## Commands
 


### PR DESCRIPTION
If the developer does not have a default credential setting, they may end up having the following error:

```
Upload error: TimeoutError: Missing credentials in config (TimeoutError: Missing credentials in config
    at ClientRequest.<anonymous> (/Users/alvincrespo/.nvm/versions/node/v6.5.0/lib/node_modules/s3-deploy/node_modules/aws-sdk/lib/http/node.js:56:34)
    at ClientRequest.g (events.js:286:16)
    at emitNone (events.js:86:13)
    at ClientRequest.emit (events.js:185:7)
    at Socket.emitTimeout (_http_client.js:614:10)
    at Socket.g (events.js:286:16)
    at emitNone (events.js:86:13)
    at Socket.emit (events.js:185:7)
    at Socket._onTimeout (net.js:334:8)
    at tryOnTimeout (timers.js:232:11))
```

This is because out of the box, the AWS library looks for the `[default]` settings. To fix this, the developer must define the following in `~/.aws/credentials`:

```
[default]
aws_access_key_id = XXX123
aws_secret_access_key = 123XXX456
```