### PR TITLE
support for setting the extension as optional parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Use this parameter to specify that objects being uploaded will be stored with pr
 ```
 --ext
 ```
-Enables to set the files' extension in case when the files without one or if there is need to override the extension (`--ext html`)
+Enables to set the correct content type header when files has no extension. For example, when the s3 bucket is used for webhosting and there is need to access paths like `/about` instead of `/about.html` so its possible to upload file named `about` and set `--ext html`
 
 ## AWS Credentials
 AWS credentials can be provided via environment variables, or in the `~/.aws/credentials` file.  More details here:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ You can specify a specific AWS profile to use to connect to S3 (defaults to `def
 ```
 Use this parameter to specify that objects being uploaded will be stored with private ACL (Owner gets FULL_CONTROL. No one else has access rights). By default, 'public-read' ACL is set. More information on the canned-acl is available in the [AWS docs](http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl)
 
+```
+--ext
+```
+Enables to set the files' extension in case when the files without one or if there is need to override the extension (`--ext html`)
+
 ## AWS Credentials
 AWS credentials can be provided via environment variables, or in the `~/.aws/credentials` file.  More details here:
 http://docs.aws.amazon.com/cli/latest/topic/config-vars.html. Please make sure to define a default in your AWS credentials, this will help prevent a `Missing Credentials` error during deployment.
@@ -89,6 +94,12 @@ Invokes eslint validation based on rules defined in the `.eslintrc` file.
 - After changes are merged into master branch, checkout master branch, run tests one more time, and publish this package to npm repository.
 
 ## Changelog
+
+### 0.7.3
+
+**API Additions**
+
+- Adding the ability to set the extension if the files without one or there is need to override it
 
 ### 0.7.2
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3-deploy",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "NodeJS bash utility for deploying files to Amazon S3",
   "scripts": {
     "test": "mocha",

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -17,13 +17,13 @@ import * as MSG from './MSG';
  * @param  {Object} opts   Object with additional AWS parameters.
  * @return {Promise}        Returns a promise which resolves with a log message of upload status.
  */
-export function upload(client, file, opts, filePrefix) {
+export function upload(client, file, opts, filePrefix, ext) {
   return new Promise((resolve, reject) => {
     opts = Object.assign({
       ACL: 'public-read'
     }, opts);
 
-    var params = Object.assign({}, utils.buildUploadParams(file, filePrefix), opts);
+    var params = Object.assign({}, utils.buildUploadParams(file, filePrefix, ext), opts);
     params = utils.handleETag(params);
     var dest = params.Key;
 
@@ -93,7 +93,7 @@ export const readFile = co.wrap(function *(filepath, cwd, gzipFiles) {
  * checking if file is already in AWS bucket and needs updates,
  * and uploading files that are not there yet, or do need an update.
  */
-export const handleFile = co.wrap(function *(filePath, cwd, filePrefix, client, s3Options) {
+export const handleFile = co.wrap(function *(filePath, cwd, filePrefix, client, s3Options, ext) {
   const fileObject = yield readFile(filePath, cwd, s3Options.ContentEncoding !== undefined);
 
   if(fileObject !== undefined) {
@@ -104,7 +104,7 @@ export const handleFile = co.wrap(function *(filePath, cwd, filePrefix, client, 
       return;
     }
 
-    const fileUploadStatus = yield upload(client, fileObject, s3Options, filePrefix);
+    const fileUploadStatus = yield upload(client, fileObject, s3Options, filePrefix, ext);
     console.log(fileUploadStatus);
   }
 });
@@ -132,6 +132,6 @@ export const deploy = co.wrap(function *(files, options, AWSOptions, s3Options, 
   var client = new AWS.S3(clientOptions);
 
   yield Promise.all(files.map(function(filePath) {
-    return handleFile(filePath, cwd, filePrefix, client, s3Options);
+    return handleFile(filePath, cwd, filePrefix, client, s3Options, options.ext);
   }));
 });

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,10 @@ co(function *() {
     options.private = true;
   }
 
+  if(argv.hasOwnProperty('ext')) {
+    options.ext = argv.ext;
+  }
+
   if(argv.hasOwnProperty('signatureVersion')) {
     options.signatureVersion = argv.signatureVersion;
   }
@@ -51,6 +55,8 @@ co(function *() {
   console.log('> Gzip:', options.gzip);
   console.log('> Cache-Control max-age=:', options.cache);
   console.log('> E-Tag:', options.etag);
+  console.log('> Private:', options.private ? true : false);
+  if (options.ext) console.log('> Ext:', options.ext);
 
   const AWSOptions = {
     region: options.region

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,8 +7,8 @@ import mime from 'mime';
  * @param  {String} src Path to file fow which content type should be evaluated.
  * @return {String}     Returns string with content type and charset.
  */
-export function contentType(src) {
-  var type = mime.lookup(src).replace('-', '');
+export function contentType(src, ext) {
+  var type = mime.lookup(ext || src).replace('-', '');
   var charset = mime.charsets.lookup(type, null);
 
   if (charset) {
@@ -59,11 +59,11 @@ export function buildBaseParams(file, filePrefix) {
  * @param  {Object} file File object, with all it's details.
  * @return {Object}      AWS S3 upload function parameters.
  */
-export function buildUploadParams(file, filePrefix) {
+export function buildUploadParams(file, filePrefix, ext) {
   var params = Object.assign({
     ContentMD5: base64Md5(file.contents),
     Body: file.contents,
-    ContentType: contentType(file.path)
+    ContentType: contentType(file.path, ext)
   }, buildBaseParams(file, filePrefix));
 
   return params;


### PR DESCRIPTION
Enables to set the correct content type header when files has no extension. For example, when the s3 bucket is used for webhosting and there is need to access paths like `/about` instead of `/about.html` so its possible to upload file named `about` and set `--ext html`