### PR TITLE
add cache control immutable header

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Specifying `--gzip` will gzip all files before sending them.
 Use this parameter to specify the `Cache-Control: max-age=X` header, where X is the number of seconds a given item will be kept in the cache for. By default this value is undefined.
 
 ```
+--immutable
+```
+When a page is refreshed, which is an extremely common social media scenario, elements that were previously marked immutable with an HTTP response header do not have to be revalidated with the server. It sets the `Cache-Control: immutable` header - [using-immutable-caching-to-speed-up-the-web](https://hacks.mozilla.org/2017/01/using-immutable-caching-to-speed-up-the-web/)
+
+```
 --etag X
 ```
 You can also specify the `ETag: X` header, where X is either user-defined value for this header, or MD5 of the content. To automatically fill this header with MD5 hash of the file, just use `--etag` parameter without any value. Internally the tool will generate MD5 hash of the content and will set it as the ETag header value. By default this parameter is undefined.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3-deploy",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "NodeJS bash utility for deploying files to Amazon S3",
   "scripts": {
     "test": "mocha",

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,10 @@ co(function *() {
     options.cache = argv.cache;
   }
 
+  if(argv.hasOwnProperty('immutable')) {
+    options.immutable = true;
+  }
+
   if(argv.hasOwnProperty('etag')) {
     options.etag = argv.etag;
   }
@@ -49,11 +53,16 @@ co(function *() {
     return glob.sync(pattern);
   }));
 
+  let cacheControl = []
+  if (options.cache) cacheControl.push('max-age=' + options.cache)
+  if (options.immutable) cacheControl.push('immutable')
+  cacheControl = cacheControl.length ? cacheControl.join(', ') : undefined
+
   console.log('Deploying files: %s', globbedFiles);
   console.log('> Target S3 bucket: %s (%s region)', options.bucket, options.region);
   console.log('> Target file prefix: %s', options.filePrefix);
   console.log('> Gzip:', options.gzip);
-  console.log('> Cache-Control max-age=:', options.cache);
+  console.log('> Cache-Control:', cacheControl);
   console.log('> E-Tag:', options.etag);
   console.log('> Private:', options.private ? true : false);
   if (options.ext) console.log('> Ext:', options.ext);
@@ -65,12 +74,12 @@ co(function *() {
   const s3Options = {
     Bucket: options.bucket,
     ContentEncoding: options.gzip,
-    CacheControl: options.cache ? 'max-age=' + options.cache : undefined,
+    CacheControl: cacheControl
   };
 
   if(options.hasOwnProperty('etag')) {
     s3Options.Metadata = {
-      ETag: options.etag,
+      ETag: options.etag
     };
   }
 


### PR DESCRIPTION
When a page is refreshed, which is an extremely common social media scenario, elements that were previously marked immutable with an HTTP response header do not have to be revalidated with the server. This PR sets the `Cache-Control: immutable` header when specified - [using-immutable-caching-to-speed-up-the-web](https://hacks.mozilla.org/2017/01/using-immutable-caching-to-speed-up-the-web/)