### PR TITLE
Commit the dist dir to facilitate programmatic access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-dist/
 node_modules/
 npm-debug.log
 .node-version

--- a/dist/MSG.js
+++ b/dist/MSG.js
@@ -1,0 +1,9 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+var SKIP_MATCHES = exports.SKIP_MATCHES = 'File Matches, skipped %s';
+var UPLOAD_SUCCESS = exports.UPLOAD_SUCCESS = 'Uploaded: %s/%s';
+var ERR_UPLOAD = exports.ERR_UPLOAD = 'Upload error: %s (%s)';
+var ERR_CHECKSUM = exports.ERR_CHECKSUM = '%s error: expected hash: %s but found %s for %s';

--- a/dist/deploy.js
+++ b/dist/deploy.js
@@ -1,0 +1,243 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.deploy = exports.handleFile = exports.readFile = undefined;
+exports.upload = upload;
+exports.sync = sync;
+
+var _util = require('util');
+
+var _util2 = _interopRequireDefault(_util);
+
+var _path = require('path');
+
+var _path2 = _interopRequireDefault(_path);
+
+var _zlib = require('zlib');
+
+var _zlib2 = _interopRequireDefault(_zlib);
+
+var _awsSdk = require('aws-sdk');
+
+var _awsSdk2 = _interopRequireDefault(_awsSdk);
+
+var _clone = require('lodash/lang/clone');
+
+var _clone2 = _interopRequireDefault(_clone);
+
+var _coFsExtra = require('co-fs-extra');
+
+var _coFsExtra2 = _interopRequireDefault(_coFsExtra);
+
+var _co = require('co');
+
+var _co2 = _interopRequireDefault(_co);
+
+var _utils = require('./utils');
+
+var utils = _interopRequireWildcard(_utils);
+
+var _MSG = require('./MSG');
+
+var MSG = _interopRequireWildcard(_MSG);
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * Uploads a file to AWS S3 bucket.
+ * @param  {Object} client AWS Client object.
+ * @param  {Object} file   File details of a file to be uploaded.
+ * @param  {Object} opts   Object with additional AWS parameters.
+ * @return {Promise}        Returns a promise which resolves with a log message of upload status.
+ */
+function upload(client, file, opts, filePrefix, ext) {
+  return new Promise(function (resolve, reject) {
+    opts = Object.assign({
+      ACL: 'public-read'
+    }, opts);
+
+    var params = Object.assign({}, utils.buildUploadParams(file, filePrefix, ext), opts);
+    params = utils.handleETag(params);
+    var dest = params.Key;
+
+    // Upload the file to s3.
+    client.putObject(params, function (err) {
+      if (err) {
+        return reject(_util2.default.format(MSG.ERR_UPLOAD, err, err.stack));
+      }
+
+      return resolve(_util2.default.format(MSG.UPLOAD_SUCCESS, params.Bucket, dest));
+    });
+  });
+}
+
+/**
+ * Checks if file is already in the S3 bucket.
+ * @param  {Object} client AWS Client object.
+ * @param  {Object} file   File details of a file to check.
+ * @param  {Object} opts   Object with additional AWS parameters.
+ * @return {Promise}       Returns a promise which rejects if file already exists,
+ *                         and doesn't need update. Otherwise fulfills.
+ */
+function sync(client, file, opts, filePrefix) {
+  return new Promise(function (resolve, reject) {
+    var params = Object.assign({
+      IfNoneMatch: utils.createMd5Hash(file.contents),
+      IfUnmodifiedSince: file.stat.mtime
+    }, utils.buildBaseParams(file, filePrefix), opts);
+
+    client.headObject(params, function (err) {
+      if (err && (err.statusCode === 304 || err.statusCode === 412)) {
+        return reject(_util2.default.format(MSG.SKIP_MATCHES, params.Key));
+      }
+
+      resolve();
+    });
+  });
+}
+
+/**
+ * Checks if the provided path is a file or directory.
+ * If it is a file, it returns file details object.
+ * Otherwise it returns undefined.
+ */
+var readFile = exports.readFile = _co2.default.wrap(regeneratorRuntime.mark(function _callee(filepath, cwd, gzipFiles) {
+  var stat, fileContents;
+  return regeneratorRuntime.wrap(function _callee$(_context) {
+    while (1) {
+      switch (_context.prev = _context.next) {
+        case 0:
+          stat = _coFsExtra2.default.statSync(filepath);
+
+          if (!stat.isFile()) {
+            _context.next = 7;
+            break;
+          }
+
+          _context.next = 4;
+          return _coFsExtra2.default.readFile(filepath, { encoding: null });
+
+        case 4:
+          fileContents = _context.sent;
+
+
+          if (gzipFiles) {
+            fileContents = _zlib2.default.gzipSync(fileContents);
+          }
+
+          return _context.abrupt('return', {
+            stat: stat,
+            contents: fileContents,
+            base: _path2.default.join(process.cwd(), cwd),
+            path: _path2.default.join(process.cwd(), filepath)
+          });
+
+        case 7:
+          return _context.abrupt('return', undefined);
+
+        case 8:
+        case 'end':
+          return _context.stop();
+      }
+    }
+  }, _callee, this);
+}));
+
+/**
+ * Handles a path, by obtaining file details for a provided path,
+ * checking if file is already in AWS bucket and needs updates,
+ * and uploading files that are not there yet, or do need an update.
+ */
+var handleFile = exports.handleFile = _co2.default.wrap(regeneratorRuntime.mark(function _callee2(filePath, cwd, filePrefix, client, s3Options, ext) {
+  var fileObject, fileUploadStatus;
+  return regeneratorRuntime.wrap(function _callee2$(_context2) {
+    while (1) {
+      switch (_context2.prev = _context2.next) {
+        case 0:
+          _context2.next = 2;
+          return readFile(filePath, cwd, s3Options.ContentEncoding !== undefined);
+
+        case 2:
+          fileObject = _context2.sent;
+
+          if (!(fileObject !== undefined)) {
+            _context2.next = 17;
+            break;
+          }
+
+          _context2.prev = 4;
+          _context2.next = 7;
+          return sync(client, fileObject, filePrefix, s3Options);
+
+        case 7:
+          _context2.next = 13;
+          break;
+
+        case 9:
+          _context2.prev = 9;
+          _context2.t0 = _context2['catch'](4);
+
+          console.log(_context2.t0);
+          return _context2.abrupt('return');
+
+        case 13:
+          _context2.next = 15;
+          return upload(client, fileObject, s3Options, filePrefix, ext);
+
+        case 15:
+          fileUploadStatus = _context2.sent;
+
+          console.log(fileUploadStatus);
+
+        case 17:
+        case 'end':
+          return _context2.stop();
+      }
+    }
+  }, _callee2, this, [[4, 9]]);
+}));
+
+/**
+ * Entry point, creates AWS client, prepares AWS options,
+ * and handles all provided paths.
+ */
+var deploy = exports.deploy = _co2.default.wrap(regeneratorRuntime.mark(function _callee3(files, options, AWSOptions, s3Options) {
+  var clientOptions = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : {};
+  var cwd, filePrefix, credentials, client;
+  return regeneratorRuntime.wrap(function _callee3$(_context3) {
+    while (1) {
+      switch (_context3.prev = _context3.next) {
+        case 0:
+          AWSOptions = (0, _clone2.default)(AWSOptions, true);
+          s3Options = (0, _clone2.default)(s3Options, true);
+          cwd = options.cwd;
+          filePrefix = options.filePrefix || '';
+
+
+          if (options.profile) {
+            credentials = new _awsSdk2.default.SharedIniFileCredentials({ profile: options.profile });
+
+            _awsSdk2.default.config.credentials = credentials;
+          }
+
+          _awsSdk2.default.config.update(Object.assign({
+            sslEnabled: true
+          }, AWSOptions));
+
+          client = new _awsSdk2.default.S3(clientOptions);
+          _context3.next = 9;
+          return Promise.all(files.map(function (filePath) {
+            return handleFile(filePath, cwd, filePrefix, client, s3Options, options.ext);
+          }));
+
+        case 9:
+        case 'end':
+          return _context3.stop();
+      }
+    }
+  }, _callee3, this);
+}));

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,143 @@
+'use strict';
+
+require('babel-polyfill');
+
+var _glob = require('glob');
+
+var _glob2 = _interopRequireDefault(_glob);
+
+var _flatten = require('lodash/array/flatten');
+
+var _flatten2 = _interopRequireDefault(_flatten);
+
+var _minimist = require('minimist');
+
+var _minimist2 = _interopRequireDefault(_minimist);
+
+var _co = require('co');
+
+var _co2 = _interopRequireDefault(_co);
+
+var _deploy = require('./deploy');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _co2.default)(regeneratorRuntime.mark(function _callee() {
+  var argv, options, globbedFiles, cacheControl, AWSOptions, s3Options, s3ClientOptions;
+  return regeneratorRuntime.wrap(function _callee$(_context) {
+    while (1) {
+      switch (_context.prev = _context.next) {
+        case 0:
+          // Get arguments that were passed from the command line.
+          argv = (0, _minimist2.default)(process.argv.slice(2));
+
+          // Create options object, based on command line arguments.
+
+          options = {
+            bucket: argv.bucket,
+            region: argv.r || argv.region || 'us-east-1',
+            cwd: argv.cwd || '',
+            profile: argv.profile,
+            gzip: argv.gzip ? 'gzip' : undefined
+          };
+
+
+          if (argv.hasOwnProperty('filePrefix')) {
+            options.filePrefix = argv.filePrefix;
+          }
+
+          if (argv.hasOwnProperty('cache')) {
+            options.cache = argv.cache;
+          }
+
+          if (argv.hasOwnProperty('immutable')) {
+            options.immutable = true;
+          }
+
+          if (argv.hasOwnProperty('etag')) {
+            options.etag = argv.etag;
+          }
+
+          if (argv.hasOwnProperty('private')) {
+            options.private = true;
+          }
+
+          if (argv.hasOwnProperty('ext')) {
+            options.ext = argv.ext;
+          }
+
+          if (argv.hasOwnProperty('signatureVersion')) {
+            options.signatureVersion = argv.signatureVersion;
+          }
+
+          // Get paths of all files from the glob pattern(s) that were passed as the
+          // unnamed command line arguments.
+          globbedFiles = (0, _flatten2.default)(argv._.filter(Boolean).map(function (pattern) {
+            return _glob2.default.sync(pattern);
+          }));
+          cacheControl = [];
+
+          if (typeof options.cache == 'number') cacheControl.push('max-age=' + options.cache);
+          if (options.immutable) cacheControl.push('immutable');
+          cacheControl = cacheControl.length ? cacheControl.join(', ') : undefined;
+
+          console.log('Deploying files: %s', globbedFiles);
+          console.log('> Target S3 bucket: %s (%s region)', options.bucket, options.region);
+          console.log('> Target file prefix: %s', options.filePrefix);
+          console.log('> Gzip:', options.gzip);
+          console.log('> Cache-Control:', cacheControl);
+          console.log('> E-Tag:', options.etag);
+          console.log('> Private:', options.private ? true : false);
+          if (options.ext) console.log('> Ext:', options.ext);
+
+          AWSOptions = {
+            region: options.region
+          };
+          s3Options = {
+            Bucket: options.bucket,
+            ContentEncoding: options.gzip,
+            CacheControl: cacheControl
+          };
+
+
+          if (options.hasOwnProperty('etag')) {
+            s3Options.Metadata = {
+              ETag: options.etag
+            };
+          }
+
+          if (options.private) {
+            s3Options.ACL = 'private';
+          }
+
+          s3ClientOptions = {};
+
+
+          if (options.hasOwnProperty('signatureVersion')) {
+            s3ClientOptions.signatureVersion = options.signatureVersion;
+          }
+
+          // Starts the deployment of all found files.
+          _context.next = 30;
+          return (0, _deploy.deploy)(globbedFiles, options, AWSOptions, s3Options, s3ClientOptions);
+
+        case 30:
+          return _context.abrupt('return', _context.sent);
+
+        case 31:
+        case 'end':
+          return _context.stop();
+      }
+    }
+  }, _callee, this);
+})).then(function () {
+  console.log('All files uploaded.');
+}).catch(function (err) {
+  if (err.stack) {
+    console.error(err.stack);
+  } else {
+    console.error(String(err));
+  }
+
+  process.exit(1); // eslint-disable-line
+});

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -1,0 +1,96 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.contentType = contentType;
+exports.createMd5Hash = createMd5Hash;
+exports.base64Md5 = base64Md5;
+exports.buildBaseParams = buildBaseParams;
+exports.buildUploadParams = buildUploadParams;
+exports.handleETag = handleETag;
+
+var _crypto = require('crypto');
+
+var _crypto2 = _interopRequireDefault(_crypto);
+
+var _mime = require('mime');
+
+var _mime2 = _interopRequireDefault(_mime);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * Gets the content type of the file, based on it's extension.
+ * @param  {String} src Path to file fow which content type should be evaluated.
+ * @return {String}     Returns string with content type and charset.
+ */
+function contentType(src, ext) {
+  var type = _mime2.default.lookup(ext || src).replace('-', '');
+  var charset = _mime2.default.charsets.lookup(type, null);
+
+  if (charset) {
+    type += '; charset=' + charset;
+  }
+
+  return type;
+}
+
+/**
+ * Creates an MD5 hash of a give file.
+ * @param  {String} data Contents of the file.
+ * @return {String}      MD5 Hash of the file contents, returned as HEX string.
+ */
+function createMd5Hash(data) {
+  return _crypto2.default.createHash('md5').update(data).digest('hex');
+}
+
+/**
+ * Creates an MD5 hash of a give file.
+ * @param  {String} data Contents of the file.
+ * @return {String}      MD5 Hash of the file contents, returned as Base64 string.
+ */
+function base64Md5(data) {
+  return _crypto2.default.createHash('md5').update(data).digest('base64');
+}
+
+/**
+ * Returns a 'Key' attribute of a request to get info about file in AWS S3.
+ * @param  {Object} file File object with information bout it's path.
+ * @return {Object}      Returns an object with a 'Key' parameter,
+ *                       being a base path of the file location, with slashes
+ *                       removed from the path.
+ */
+function buildBaseParams(file, filePrefix) {
+  var dest = file.path.replace(file.base, '');
+  dest = dest.replace(/^\//, '');
+  if (filePrefix) {
+    dest = filePrefix + '/' + dest;
+  }
+  return {
+    Key: dest
+  };
+}
+
+/**
+ * Takes a file object, and prepares parameters required during AWS S3 file upload.
+ * @param  {Object} file File object, with all it's details.
+ * @return {Object}      AWS S3 upload function parameters.
+ */
+function buildUploadParams(file, filePrefix, ext) {
+  var params = Object.assign({
+    ContentMD5: base64Md5(file.contents),
+    Body: file.contents,
+    ContentType: contentType(file.path, ext)
+  }, buildBaseParams(file, filePrefix));
+
+  return params;
+}
+
+function handleETag(opts) {
+  if (opts.Metadata && opts.Metadata.ETag === true) {
+    opts.Metadata.ETag = opts.ContentMD5;
+  }
+
+  return opts;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -53,10 +53,10 @@ co(function *() {
     return glob.sync(pattern);
   }));
 
-  let cacheControl = []
-  if (options.cache) cacheControl.push('max-age=' + options.cache)
-  if (options.immutable) cacheControl.push('immutable')
-  cacheControl = cacheControl.length ? cacheControl.join(', ') : undefined
+  let cacheControl = [];
+  if (typeof options.cache == 'number') cacheControl.push('max-age=' + options.cache);
+  if (options.immutable) cacheControl.push('immutable');
+  cacheControl = cacheControl.length ? cacheControl.join(', ') : undefined;
 
   console.log('Deploying files: %s', globbedFiles);
   console.log('> Target S3 bucket: %s (%s region)', options.bucket, options.region);


### PR DESCRIPTION
The .bin/s3-deploy helper points to the dist directory, which does not exist in distributions of this package.

```
#!/usr/bin/env node

require('./../dist/index.js');
```

Instead of pointing to the src directory, which could mean we miss out on issues introduced by the build process, commit the output of the distribution with the package. This allows you to access the project programmatically:

```
const spawn = require('child_process').spawn;
const path = require('path');
const deployAssets = spawn(path.join(__dirname, '..', 'node_modules/s3-deploy/.bin/s3-deploy'), [
	path.join(__dirname, '..', 'dist/**'),
	'--cwd',
	path.join(__dirname, '..', 'dist/'),
	'--bucket',
	'testbucket',
	'--region',
	'ap-southeast-2',
	'--profile',
	'profileName',
	'--etag'
]);
```