### PR TITLE
Allow cache-control to be set to 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3-deploy",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "NodeJS bash utility for deploying files to Amazon S3",
   "scripts": {
     "test": "mocha",

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ co(function *() {
   }));
 
   let cacheControl = [];
-  if (Object.keys(options).indexOf('cache') > -1) cacheControl.push('max-age=' + options.cache);
+  if (options.hasOwnProperty('cache')) cacheControl.push('max-age=' + options.cache);
   if (options.immutable) cacheControl.push('immutable');
   cacheControl = cacheControl.length ? cacheControl.join(', ') : undefined;
 

--- a/src/index.js
+++ b/src/index.js
@@ -53,10 +53,10 @@ co(function *() {
     return glob.sync(pattern);
   }));
 
-  let cacheControl = []
-  if (options.cache) cacheControl.push('max-age=' + options.cache)
-  if (options.immutable) cacheControl.push('immutable')
-  cacheControl = cacheControl.length ? cacheControl.join(', ') : undefined
+  let cacheControl = [];
+  if (options.cache) cacheControl.push('max-age=' + options.cache);
+  if (options.immutable) cacheControl.push('immutable');
+  cacheControl = cacheControl.length ? cacheControl.join(', ') : undefined;
 
   console.log('Deploying files: %s', globbedFiles);
   console.log('> Target S3 bucket: %s (%s region)', options.bucket, options.region);

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ co(function *() {
   }));
 
   let cacheControl = [];
-  if (options.cache) cacheControl.push('max-age=' + options.cache);
+  if (Object.keys(options).indexOf('cache') > -1) cacheControl.push('max-age=' + options.cache);
   if (options.immutable) cacheControl.push('immutable');
   cacheControl = cacheControl.length ? cacheControl.join(', ') : undefined;
 


### PR DESCRIPTION
This checks to see if `cache` is provided, rather that checking if it is truthy.

Also, fix the lint, as master doesn't install correctly locally.