### PR TITLE
Windows file path fix

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 import crypto from 'crypto';
-
+import path from 'path';
 import mime from 'mime';
 
 /**
@@ -44,8 +44,7 @@ export function base64Md5(data) {
  *                       removed from the path.
  */
 export function buildBaseParams(file, filePrefix) {
-  var dest = file.path.replace(file.base, '');
-  dest = dest.replace(/^\//, '');
+  var dest = path.basename(file.path);
   if (filePrefix) {
     dest = filePrefix + '/' + dest;
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,7 +44,7 @@ export function base64Md5(data) {
  *                       removed from the path.
  */
 export function buildBaseParams(file, filePrefix) {
-  var dest = path.basename(file.path);
+  var dest = path.relative(file.base, file.path).replace(/\\/g,'/');
   if (filePrefix) {
     dest = filePrefix + '/' + dest;
   }


### PR DESCRIPTION
If you uploaded a file, it could get the whole path as a name, for example `C:\a\b\c\d.js`
instead of just `c.js`.

Windows doesn't like `--cwd './dist'`  so you'll have to do `--cwd \"./dist\"` 
The reason seems to be the package `minimist`. If you use single-quote then minimist will set `argv.cwd` in `index.js` to `'./dist'`  

`s3-deploy \"dist/*.md\" --cwd \"./\" --bucket BUCKETNAME --filePrefix test`
will create a file called 
`\dist\this-is-a-very-unique-name.md` in the folder `test`, but it should create a folder called `dist`in the folder `test`. `dist` should contain the file.


This should close #31 
I've tested on mac and windows




