### PR TITLE
Add --index option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Enables to set the correct content type header when files has no extension. For 
 
 Removes files in S3, that are not available in the local copy of the directory. Useful to cleanup files that should no longer reside in the remote version.
 
+```
+--index
+```
+
+If a filename in a subdirectory matches the index file, then upload two additional copies of the file: one with the same name as the directory, and one with the name of the directory followed by "/".  This can be used to fake "index.html" on S3 and CloudFront, which normally has no concept of default index files.
+
 ## AWS Credentials
 AWS credentials can be provided via environment variables, or in the `~/.aws/credentials` file.  More details here:
 http://docs.aws.amazon.com/cli/latest/topic/config-vars.html. Please make sure to define a default in your AWS credentials, this will help prevent a `Missing Credentials` error during deployment.

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ co(function *() {
     cwd: argv.cwd || '',
     profile: argv.profile,
     gzip: (argv.gzip ? 'gzip' : undefined),
+    index: argv.index || null,
   };
 
   if(argv.hasOwnProperty('filePrefix')) {
@@ -51,6 +52,10 @@ co(function *() {
     options.deleteRemoved = argv.deleteRemoved;
   }
 
+  if(argv.hasOwnProperty('index')) {
+    options.index = argv.index;
+  }
+
   // Get paths of all files from the glob pattern(s) that were passed as the
   // unnamed command line arguments.
   const globbedFiles = flatten(argv._.filter(Boolean).map(function(pattern) {
@@ -70,6 +75,7 @@ co(function *() {
   console.log('> E-Tag:', options.etag);
   console.log('> Private:', options.private ? true : false);
   if (options.ext) console.log('> Ext:', options.ext);
+  if (options.index) console.log('> Index:', options.index);
 
   const AWSOptions = {
     region: options.region


### PR DESCRIPTION
S3 doesn't support index.html and friends without complicated rules, and CloudFront doesn't support it at all (aside from the root object).

Add an argument --index to upload two additional copies of files whose name matches the argument: One with the name of the directory, and one with the name of the directory + "/".