### PR TITLE
Add ability to prevent an upload from changing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,17 @@ Specifying `--gzip` will gzip all files before sending them.
 Use this parameter to specify the `Cache-Control: max-age=X` header, where X is the number of seconds a given item will be kept in the cache for. By default this value is undefined.
 
 ```
---immutable
+--preventUpdates
 ```
-When a page is refreshed, which is an extremely common social media scenario, elements that were previously marked immutable with an HTTP response header do not have to be revalidated with the server. It sets the `Cache-Control: immutable` header - [using-immutable-caching-to-speed-up-the-web](https://hacks.mozilla.org/2017/01/using-immutable-caching-to-speed-up-the-web/)
+Use this parameter to validate that the object either currently does not exist in the bucket, or
+that it already matches the ETag hash and thus is skipped and not uploaded. This effectively ensures that S3 Objects will not be modified. This is useful with the `--immutable` flag.
+```
 
 ```
+--immutable
+```
+When a page is refreshed, which is an extremely common social media scenario, elements that were previously marked immutable with an HTTP response header do not have to be revalidated with the server. It sets the `Cache-Control: immutable` header - [using-immutable-caching-to-speed-up-the-web](https://hacks.mozilla.org/2017/01/using-immutable-caching-to-speed-up-the-web/) This is useful with the `--preventUpdates` flag.
+
 --etag X
 ```
 You can also specify the `ETag: X` header, where X is either user-defined value for this header, or MD5 of the content. To automatically fill this header with MD5 hash of the file, just use `--etag` parameter without any value. Internally the tool will generate MD5 hash of the content and will set it as the ETag header value. By default this parameter is undefined.

--- a/src/MSG.js
+++ b/src/MSG.js
@@ -1,5 +1,6 @@
 export const SKIP_MATCHES = 'File Matches, skipped %s';
 export const UPLOAD_SUCCESS = 'Uploaded: %s/%s';
 export const ERR_UPLOAD = 'Upload error: %s (%s)';
-export const ERR_CHECKSUM = '%s error: expected hash: %s but found %s for %s';
+export const ERR_CHECKSUM = 'Update prevented: local hash is %s but bucket hash is %s for %s';
 export const DELETE_SUCCESS = 'Deleted: %s';
+export const ABORT_UPLOAD = 'Unexpected error: (%s) %s, aborting upload for %s';

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,10 @@ co(function *() {
     options.immutable = true;
   }
 
+  if(argv.hasOwnProperty('preventUpdates')) {
+    options.preventUpdates = true;
+  }
+
   if(argv.hasOwnProperty('etag')) {
     options.etag = argv.etag;
   }
@@ -71,6 +75,7 @@ co(function *() {
   console.log('> Target S3 bucket: %s (%s region)', options.bucket, options.region);
   console.log('> Target file prefix: %s', options.filePrefix);
   console.log('> Gzip:', options.gzip);
+  console.log('> Prevent Updates:', options.preventUpdates);
   console.log('> Cache-Control:', cacheControl);
   console.log('> E-Tag:', options.etag);
   console.log('> Private:', options.private ? true : false);
@@ -107,7 +112,7 @@ co(function *() {
   return yield deploy(globbedFiles, options, AWSOptions, s3Options, s3ClientOptions);
 })
 .then(() => {
-  console.log('All files uploaded.');
+  console.log('Upload finished');
 })
 .catch(err => {
   if (err.stack) {


### PR DESCRIPTION
Related to #38 

After peeking around in your code, it was obvious that you already do a HEAD on each object to prevent redundant uploads. I figured that would be the biggest performance impact of my desired change and since you are already doing that, it would be easy to add an additional check to prevent changing objects if desired.

Let me know what you think. Thanks for the project, by the way!