### PR TITLE
HTML Video files shouldn't be gzipped

### DIFF
--- a/src/deploy.js
+++ b/src/deploy.js
@@ -131,7 +131,7 @@ export const readFile = co.wrap(function *(filepath, cwd, gzipFiles) {
   if (stat.isFile()) {
     let fileContents = yield fs.readFile(filepath, {encoding: null});
 
-    if (gzipFiles) {
+    if (gzipFiles && !filepath.endsWith('.mp4')) {
       fileContents = zlib.gzipSync(fileContents);
     }
 


### PR DESCRIPTION
Gzipping MP4 video files will break the streaming. The server will send a response header 206 and the first chunk will download but the video will never play.