### PR TITLE
Predefine file extensions to gzip. Make the list customizable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Deploys files found by the `./dist/**` glob patten to S3. Change `AWS_REGION` wi
 ### Optional parameters
 
 ```
---gzip [EXTENSIONS="xml,html,htm,js,css,ttf,otf,svg,txt"]
+--gzip [ETX,...]
 ```
 
-Specifying `--gzip` will gzip all files matching the file extensions before sending them to S3, and adds appropriate `Content-Encoding: gzip` metadata attribute on uploaded elements in S3, so that when they are opened in the browser, the browser knows to decompress them first before displaying. If extensions list is missing the default list is `xml,html,htm,js,css,ttf,otf,svg,txt`.
+Specifying `--gzip` will gzip all files before sending them to S3, and adds appropriate `Content-Encoding: gzip` metadata attribute on uploaded elements in S3, so that when they are opened in the browser, the browser knows to decompress them first before displaying. You can specify the list of file extensions to gzip, e.g. `--gzip xml,html,htm,js,css,ttf,otf,svg,txt`.
 
 ```
 --cache X

--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ Invokes eslint validation based on rules defined in the `.eslintrc` file.
 
 ## Changelog
 
+### 1.1.0
+
+**API Additions**
+
+* Pass file extensions to `--gzip` to zip only the given list. E.g. `--gzip xml,html,htm,js,css,ttf,otf,svg,txt`.
+
 ### 1.0.0
 
 **No changes**

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Deploys files found by the `./dist/**` glob patten to S3. Change `AWS_REGION` wi
 ### Optional parameters
 
 ```
---gzip
+--gzip [EXTENSIONS="xml,html,htm,js,css,ttf,otf,svg,txt"]
 ```
 
-Specifying `--gzip` will gzip all files before sending them to S3, and adds appropriate `Content-Encoding: gzip` metadata attribute on uploaded elements in S3, so that when they are opened in the browser, the browser knows to decompress them first before displaying.
+Specifying `--gzip` will gzip all files matching the file extensions before sending them to S3, and adds appropriate `Content-Encoding: gzip` metadata attribute on uploaded elements in S3, so that when they are opened in the browser, the browser knows to decompress them first before displaying. If extensions list is missing the default list is `xml,html,htm,js,css,ttf,otf,svg,txt`.
 
 ```
 --cache X

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "s3-deploy",
-  "version": "0.10.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1109,7 +1109,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "core-js": "2.5.3",
@@ -1222,7 +1221,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
       "requires": {
         "core-js": "2.5.3",
         "regenerator-runtime": "0.11.1"
@@ -1231,8 +1229,7 @@
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-          "dev": true
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
         }
       }
     },
@@ -1605,8 +1602,7 @@
     "core-js": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
-      "dev": true
+      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -4624,8 +4620,7 @@
     "regenerator-runtime": {
       "version": "0.10.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-      "dev": true
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
     },
     "regenerator-transform": {
       "version": "0.10.1",

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -234,7 +234,7 @@ export const deploy = co.wrap(function *(options) {
   const cfOptions = {};
   if (options.hasOwnProperty('distId')) {
     cfOptions.distId = options.distId;
-    cfOptions.invalidate = options.invalidate;
+    cfOptions.invalidate = options.invalidate.split(' ');
   }
   if (cfOptions.distId) {
     invalidate(cfOptions.distId, cfOptions.invalidate);

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -123,6 +123,8 @@ export function sync(client, file, filePrefix, opts, preventUpdates, fileName) {
 }
 
 export function shouldBeZipped(filepath, gzip) {
+  if (gzip === true) return true;
+
   if (Array.isArray(gzip)) {
     const ext = path.extname(filepath); // ext would be ".js" or alike
     if (ext && gzip.includes(ext.substr(1))) {

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -164,7 +164,7 @@ export const readFile = co.wrap(function *(filepath, cwd, shouldGzip) {
  * checking if file is already in AWS bucket and needs updates,
  * and uploading files that are not there yet, or do need an update.
  */
-export const handleFile = co.wrap(function *(filePath, s3Client, s3UploadOpts, {filePrefix, cwd, ext, index, preventUpdates}) {
+export const handleFile = co.wrap(function *(filePath, s3Client, s3UploadOpts, {filePrefix, cwd, ext, index, preventUpdates, console}) {
   const s3UploadOptions = {...s3UploadOpts};
   if (shouldBeZipped(filePath, s3UploadOptions.gzip)) s3UploadOptions.ContentEncoding = 'gzip';
   const fileObject = yield readFile(filePath, cwd, s3UploadOptions.ContentEncoding);
@@ -180,7 +180,7 @@ export const handleFile = co.wrap(function *(filePath, s3Client, s3UploadOpts, {
         }
       }
     } catch (e) {
-      console.log(e);
+      console.error(e);
       return;
     }
 
@@ -200,6 +200,7 @@ export const handleFile = co.wrap(function *(filePath, s3Client, s3UploadOpts, {
  * and handles all provided paths.
  */
 export const deploy = co.wrap(function *(options) {
+  options.console = options.console || global.console;
   const AWSOptions = {
     region: options.region
   };

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ co(function *() {
   };
 
   if(argv.hasOwnProperty('gzip')) {
-    options.gzip = (typeof argv.gzip === 'string' ? argv.gzip : 'xml,html,htm,js,css,ttf,otf,svg,txt').split(',');
+    options.gzip = typeof argv.gzip === 'string' ? argv.gzip.split(',') : argv.gzip;
   }
 
   if(argv.hasOwnProperty('filePrefix')) {
@@ -102,7 +102,6 @@ co(function *() {
 
   const s3Options = {
     Bucket: options.bucket,
-    ContentEncoding: options.gzip,
     CacheControl: cacheControl
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,12 @@ co(function *() {
     region: argv.r || argv.region || 'us-east-1',
     cwd: argv.cwd || '',
     profile: argv.profile,
-    gzip: (argv.gzip ? 'gzip' : undefined),
     index: argv.index || null,
   };
+
+  if(argv.hasOwnProperty('gzip')) {
+    options.gzip = (typeof argv.gzip === 'string' ? argv.gzip : 'xml,html,htm,js,css,ttf,otf,svg,txt').split(',');
+  }
 
   if(argv.hasOwnProperty('filePrefix')) {
     options.filePrefix = argv.filePrefix;

--- a/test/unit/deploy.js
+++ b/test/unit/deploy.js
@@ -4,15 +4,29 @@ const expect = chai.expect;
 const { shouldBeZipped } = require('../../src/deploy');
 
 describe('#shouldBeZipped()', async () => {
-  it('should return true for zippable file extensions', () => {
-    const extensions = ['js', 'css', 'html'];
-    expect(shouldBeZipped('/path/file.js', extensions)).to.equal(true);
+  it('should return true for all if --gzip', () => {
+    const gzip = true;
+    expect(shouldBeZipped('/path/file.js', gzip)).to.equal(true);
+    expect(shouldBeZipped('/path/file.mp4', gzip)).to.equal(true);
+    expect(shouldBeZipped('/path/file.js.mp4', gzip)).to.equal(true);
+    expect(shouldBeZipped('/path/file.', gzip)).to.equal(true);
   });
 
-  it('should return false for all unknown extensions', () => {
-    const extensions = ['js', 'css', 'html'];
-    expect(shouldBeZipped('/path/file.mp4', extensions)).to.equal(false);
-    expect(shouldBeZipped('/path/file.js.mp4', extensions)).to.equal(false);
-    expect(shouldBeZipped('/path/file.', extensions)).to.equal(false);
+  it('should return false if no --gzip', () => {
+    expect(shouldBeZipped('/path/file.js', undefined)).to.equal(false);
+    expect(shouldBeZipped('/path/file.js', false)).to.equal(false);
+    expect(shouldBeZipped('/path/file.js', 'false')).to.equal(false);
+  });
+
+  it('should return true for provided file extensions --gzip js,css,html', () => {
+    const gzip = ['js', 'css', 'html'];
+    expect(shouldBeZipped('/path/file.js', gzip)).to.equal(true);
+  });
+
+  it('should return false for all unknown extensions --gzip js,css,html', () => {
+    const gzip = ['js', 'css', 'html'];
+    expect(shouldBeZipped('/path/file.mp4', gzip)).to.equal(false);
+    expect(shouldBeZipped('/path/file.js.mp4', gzip)).to.equal(false);
+    expect(shouldBeZipped('/path/file.', gzip)).to.equal(false);
   });
 });

--- a/test/unit/deploy.js
+++ b/test/unit/deploy.js
@@ -1,0 +1,18 @@
+const chai = require('chai');
+const expect = chai.expect;
+
+const { shouldBeZipped } = require('../../src/deploy');
+
+describe('#shouldBeZipped()', async () => {
+  it('should return true for zippable file extensions', () => {
+    const extensions = ['js', 'css', 'html'];
+    expect(shouldBeZipped('/path/file.js', extensions)).to.equal(true);
+  });
+
+  it('should return false for all unknown extensions', () => {
+    const extensions = ['js', 'css', 'html'];
+    expect(shouldBeZipped('/path/file.mp4', extensions)).to.equal(false);
+    expect(shouldBeZipped('/path/file.js.mp4', extensions)).to.equal(false);
+    expect(shouldBeZipped('/path/file.', extensions)).to.equal(false);
+  });
+});

--- a/test/unit/deploy.js
+++ b/test/unit/deploy.js
@@ -45,10 +45,36 @@ describe('#handleFile()', () => {
         cb(null, {});
       },
       putObject(params, cb) {
+        expect(params).to.have.property('ACL', 'public-read');
+        expect(params).to.have.property('Bucket', 'my-bucket');
+        expect(params).to.not.have.property('ContentEncoding');
+        expect(params).to.have.property('ContentType', 'application/javascript; charset=UTF-8');
+        expect(params).to.have.property('Key', 'deploy.js');
         cb(null, {});
       }
     };
 
     handleFile(__filename, s3Client, { Bucket: 'my-bucket' }, { cwd: __dirname, console }).catch(done);
+  });
+
+  it('should upload gzipped file', done => {
+    const console = {
+      log(msg) {
+        expect(msg).to.equal('Uploaded: my-bucket/deploy.js');
+        done();
+      },
+      error: done
+    };
+    const s3Client = {
+      headObject(params, cb) {
+        cb(null, {});
+      },
+      putObject(params, cb) {
+        expect(params).to.have.property('ContentEncoding', 'gzip');
+        cb(null, {});
+      }
+    };
+
+    handleFile(__filename, s3Client, { Bucket: 'my-bucket', gzip: true }, { cwd: __dirname, console }).catch(done);
   });
 });

--- a/test/unit/deploy.js
+++ b/test/unit/deploy.js
@@ -1,9 +1,9 @@
 const chai = require('chai');
 const expect = chai.expect;
 
-const { shouldBeZipped } = require('../../src/deploy');
+const { shouldBeZipped, handleFile } = require('../../src/deploy');
 
-describe('#shouldBeZipped()', async () => {
+describe('#shouldBeZipped()', () => {
   it('should return true for all if --gzip', () => {
     const gzip = true;
     expect(shouldBeZipped('/path/file.js', gzip)).to.equal(true);
@@ -28,5 +28,27 @@ describe('#shouldBeZipped()', async () => {
     expect(shouldBeZipped('/path/file.mp4', gzip)).to.equal(false);
     expect(shouldBeZipped('/path/file.js.mp4', gzip)).to.equal(false);
     expect(shouldBeZipped('/path/file.', gzip)).to.equal(false);
+  });
+});
+
+describe('#handleFile()', () => {
+  it('should upload file', done => {
+    const console = {
+      log(msg) {
+        expect(msg).to.equal('Uploaded: my-bucket/deploy.js');
+        done();
+      },
+      error: done
+    };
+    const s3Client = {
+      headObject(params, cb) {
+        cb(null, {});
+      },
+      putObject(params, cb) {
+        cb(null, {});
+      }
+    };
+
+    handleFile(__filename, s3Client, { Bucket: 'my-bucket' }, { cwd: __dirname, console }).catch(done);
   });
 });

--- a/test/unit/deploy.js
+++ b/test/unit/deploy.js
@@ -18,12 +18,12 @@ describe('#shouldBeZipped()', async () => {
     expect(shouldBeZipped('/path/file.js', 'false')).to.equal(false);
   });
 
-  it('should return true for provided file extensions --gzip js,css,html', () => {
+  it('should return true for provided file extensions', () => {
     const gzip = ['js', 'css', 'html'];
     expect(shouldBeZipped('/path/file.js', gzip)).to.equal(true);
   });
 
-  it('should return false for all unknown extensions --gzip js,css,html', () => {
+  it('should return false for all unknown extensions', () => {
     const gzip = ['js', 'css', 'html'];
     expect(shouldBeZipped('/path/file.mp4', gzip)).to.equal(false);
     expect(shouldBeZipped('/path/file.js.mp4', gzip)).to.equal(false);

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,0 +1,16 @@
+const chai = require('chai');
+const expect = chai.expect;
+
+const { parseCliArgsToOptions } = require('../../src/index');
+
+describe('#parseCliArgsToOptions()', () => {
+  describe('--gzip', async () => {
+    it('should be true if present', () => {
+      expect(parseCliArgsToOptions([0, 0, '--gzip']).gzip).to.equal(true);
+    });
+
+    it('should be array if arg is given', () => {
+      expect(parseCliArgsToOptions([0, 0, '--gzip', 'js,css,html']).gzip).to.deep.equal(['js', 'css', 'html']);
+    });
+  });
+});


### PR DESCRIPTION
* GZIp all the files if `--gzip` is provided. If file extension list is given then gzip only those.
* Add corresponding unit tests.
* Update README accordingly.

Should be published as v1.1.