### PR TITLE
Fix invalidate argv param

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3-deploy",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "NodeJS bash utility for deploying files to Amazon S3",
   "scripts": {
     "test": "mocha",

--- a/src/index.js
+++ b/src/index.js
@@ -123,7 +123,7 @@ co(function *() {
 
   if (options.hasOwnProperty('distId')) {
     cfOptions.distId = options.distId;
-    cfOptions.invalidate = options.invalidate;
+    cfOptions.invalidate = options.invalidate.split(' ');
   }
 
   // Starts the deployment of all found files.


### PR DESCRIPTION
Previously, options.invalidate is a string split by a whitespace character. Therefore, cloudfront.js only accepts invalidate paths in array type. So, now we're splitting the string into an array.