### PR TITLE
Support delete objects recursively

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 NodeJS bash utility for deploying files to Amazon S3
 
+## Changes in this fork:
+
+- Support delete objects recursively for option `--deleteRemoved`
+- Reason: S3 listObjects only limit `MaxKeys: 1000`, so in case your deploy contains many files (much more than 1000), it may cause unexpected result (usually, it cannot delete all the necessary files)
+- This fork make sure all files in S3 will be `--deleteRemoved` if they are not matched with local files.
+
 ## Usage
 
 ```

--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 NodeJS bash utility for deploying files to Amazon S3
 
-## Changes in this fork:
-
-- Support delete objects recursively for option `--deleteRemoved`
-- Reason: S3 listObjects only limit `MaxKeys: 1000`, so in case your deploy contains many files (much more than 1000), it may cause unexpected result (usually, it cannot delete all the necessary files)
-- This fork make sure all files in S3 will be `--deleteRemoved` if they are not matched with local files.
-
 ## Usage
 
 ```
@@ -151,6 +145,14 @@ Invokes eslint validation based on rules defined in the `.eslintrc` file.
 * After changes are merged into master branch, checkout master branch, run tests one more time, and publish this package to npm repository.
 
 ## Changelog
+
+### 1.1.2
+
+**Delete S3 objects recursively**
+
+- Support delete objects recursively for option `--deleteRemoved`
+- Reason: S3 listObjects only limit `MaxKeys: 1000`, so in case your deploy contains many files (much more than 1000), it may cause unexpected result (usually, it cannot delete all the necessary files)
+- This fork make sure all files in S3 will be `--deleteRemoved` if they are not matched with local files.
 
 ### 1.1.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3-deploy",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "NodeJS bash utility for deploying files to Amazon S3",
   "scripts": {
     "test": "mocha",

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -41,7 +41,7 @@ export function upload(client, file, opts, filePrefix, ext, fileName) {
 const listAllKeys = (client, params, out = []) => new Promise((resolve, reject) => {
   client.listObjectsV2(params).promise()
     .then(({Contents, IsTruncated, NextContinuationToken}) => {
-      console.log('listObjects IsTruncated: %s', IsTruncated)
+      console.log('listObjects IsTruncated: %s', IsTruncated);
       const s3files = Contents.map(item => item.Key);
       out = out.concat(s3files);
       !IsTruncated ? resolve(out) : resolve(listAllKeys(client, Object.assign(params, {ContinuationToken: NextContinuationToken}), out));
@@ -73,7 +73,7 @@ export function deleteRemoved(client, files, options) {
           for(i=0, j=toDelete.length; i < j; i += chunk) {
             const delObjs = toDelete.slice(0, i+chunk).map(item => {
               return {Key: item};
-            })
+            });
 
             const params = {
               Bucket: options.bucket,
@@ -84,7 +84,7 @@ export function deleteRemoved(client, files, options) {
 
             client.deleteObjects(params, function (err, data) {
               if (err) {
-                console.log('Error while Deleting: ', err)
+                console.log('Error while Deleting: ', err);
                 return reject(util.format(MSG.ERR_UPLOAD, err, err.stack));
               }// an error occurred
 
@@ -95,7 +95,7 @@ export function deleteRemoved(client, files, options) {
           console.log('No files to delete.');
         }
       })
-      .catch(console.log)
+      .catch(console.log);
   });
 }
 

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -71,14 +71,16 @@ export function deleteRemoved(client, files, options) {
           let i, j, tempDeletes;
           const chunk = 1000;
           for(i=0, j=toDelete.length; i < j; i += chunk) {
-            const delObjs = toDelete.slice(0, i+chunk).map(item => {
+            tempDeletes = toDelete.slice(i, i+chunk).map(item => {
               return {Key: item};
             });
+
+            console.log('Deleting chunk: %s', tempDeletes.length);
 
             const params = {
               Bucket: options.bucket,
               Delete: {
-                Objects: delObjs
+                Objects: tempDeletes
               }
             };
 


### PR DESCRIPTION
- Support delete objects recursively for option `--deleteRemoved`
- Reason: S3 listObjects only limit `MaxKeys: 1000`, so in case your deploy contains many files (much more than 1000), it may cause unexpected result (usually, it cannot delete all the necessary files)