### PR TITLE
Do not set invalidate array for options if it is not defined

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "s3-deploy",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -256,7 +256,9 @@ export const deploy = co.wrap(function *(options) {
   const cfOptions = {};
   if (options.hasOwnProperty('distId')) {
     cfOptions.distId = options.distId;
-    cfOptions.invalidate = options.invalidate.split(' ');
+    if (cfOptions.invalidate) {
+      cfOptions.invalidate = options.invalidate.split(' ');
+    }
   }
   if (cfOptions.distId) {
     invalidate(cfOptions.distId, cfOptions.invalidate);


### PR DESCRIPTION
According to readme `invalidate` parameter is not necessary therefore we have to check whether it's defined or not, in case it's not defined we invalidate everything anyway.