### PR TITLE
Fix check for invalidation paths

### DIFF
--- a/src/deploy.js
+++ b/src/deploy.js
@@ -256,7 +256,7 @@ export const deploy = co.wrap(function *(options) {
   const cfOptions = {};
   if (options.hasOwnProperty('distId')) {
     cfOptions.distId = options.distId;
-    if (cfOptions.invalidate) {
+    if (options.hasOwnProperty('invalidate')) {
       cfOptions.invalidate = options.invalidate.split(' ');
     }
   }


### PR DESCRIPTION
Object paths for CloudFront invalidations were never set and always defaulted to '/'.