### PR TITLE
Fix invalidations

### DIFF
--- a/src/deploy.js
+++ b/src/deploy.js
@@ -256,7 +256,7 @@ export const deploy = co.wrap(function *(options) {
   const cfOptions = {};
   if (options.hasOwnProperty('distId')) {
     cfOptions.distId = options.distId;
-    if (cfOptions.invalidate) {
+    if (options.invalidate) {
       cfOptions.invalidate = options.invalidate.split(' ');
     }
   }


### PR DESCRIPTION
cfOptions.invalidate is always undefined, and any specified invalidations are ignored.