### PR TITLE
Added deleteExclude parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 coverage
 tmp/
 .npmrc
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "s3-deploy",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -62,7 +62,12 @@ export function deleteRemoved(client, files, options) {
         console.log('allKeys length: %s', allKeys.length);
         const localFiles = files.map(item => item.substr(options.cwd.length));
         console.log('localFiles length: %s', localFiles.length);
-        const toDelete = allKeys.filter(item => !localFiles.includes(item));
+        let toDelete = allKeys.filter(item => !localFiles.includes(item));
+
+        if (options.deleteExclude) {
+          const excludeFiles = options.deleteExclude.map(item => item.substr(options.cwd.length));
+          toDelete = toDelete.filter(item => !excludeFiles.includes(item));
+        }
 
         if (toDelete.length > 0) {
 

--- a/src/index.js
+++ b/src/index.js
@@ -63,10 +63,13 @@ export function parseCliArgsToOptions(processArgv = process.argv) {
     options.index = argv.index;
   }
 
-
   if(argv.hasOwnProperty('distId')) {
     options.distId = argv.distId;
     options.invalidate = argv.invalidate;
+  }
+
+  if(argv.hasOwnProperty('deleteExclude')) {
+    options.deleteExclude = glob.sync(argv.deleteExclude);
   }
 
   // Get paths of all files from the glob pattern(s) that were passed as the
@@ -94,6 +97,12 @@ function printOptions(options) {
   console.log('► Private:', options.private ? true : false);
   if (options.ext) console.log('> Ext:', options.ext);
   if (options.index) console.log('> Index:', options.index);
+  if (options.deleteRemoved) {
+    console.log('► Deleting removed files');
+    if (options.deleteExclude) {
+      console.log('  ▹ Excluding from delete: %s', options.deleteExclude);
+    }
+  }
   if (options.distId) {
     console.log('▼ CloudFront');
     console.log('  ▹ Distribution ID:', options.distId);


### PR DESCRIPTION
This pull request adds the --deleteExclude parameter.

**The issue**
There are use-cases where you want to deploy a whole site but leave specific folders intact. For example if there is an image folder on S3 where users upload their content, but on your local testing environment you only have some test images. A command to not transfer the local folder could be:

`s3-deploy '{./dist/!(images)/**,./dist/*}' --cwd './dist/' --region eu-central-1 --bucket mybucket`

This uploads the site without the "images" folder. But imagine the build process creates uniquely named css/js files for each build, then you would want to remove these each deploy. If you add `--deleteRemoved` option to the above line, the image folder on the bucket will get deleted.

**The solution**

I added a `--deleteExclude` flag. The list of files to delete is filtered through this array first, so that you can keep certain files or folders from being deleted. For the above example:

`s3-deploy '{./dist/!(images)/**,./dist/*}' --cwd './dist/' --region eu-central-1 --bucket mybucket --deleteRemoved --deleteExclude './dist/images/**'`

This will correctly preserve the selected folders when using `--deleteRemoved`