### PR TITLE
Add ability to block all caching

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,7 @@ export function parseCliArgsToOptions(processArgv = process.argv) {
   }));
 
   let cacheControl = [];
+  if (argv.hasOwnProperty('noCache')) cacheControl.push('no-cache, no-store, must-revalidate');
   if (options.hasOwnProperty('cache')) cacheControl.push('max-age=' + options.cache);
   if (options.immutable) cacheControl.push('immutable');
   options.cacheControl = cacheControl.length ? cacheControl.join(', ') : undefined;

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,10 @@ export function parseCliArgsToOptions(processArgv = process.argv) {
     options.cache = argv.cache;
   }
 
+  if(argv.hasOwnProperty('noCache')) {
+    options.noCache = true;
+  }
+
   if(argv.hasOwnProperty('immutable')) {
     options.immutable = true;
   }
@@ -74,11 +78,15 @@ export function parseCliArgsToOptions(processArgv = process.argv) {
     return glob.sync(pattern);
   }));
 
-  let cacheControl = [];
-  if (argv.hasOwnProperty('noCache')) cacheControl.push('no-cache, no-store, must-revalidate');
-  if (options.hasOwnProperty('cache')) cacheControl.push('max-age=' + options.cache);
-  if (options.immutable) cacheControl.push('immutable');
-  options.cacheControl = cacheControl.length ? cacheControl.join(', ') : undefined;
+  let cacheControl = undefined;
+  if (options.noCache) {
+    cacheControl = 'no-cache, no-store, must-revalidate';
+  } else if (options.hasOwnProperty('cache')) {
+    cacheControl = 'max-age=' + options.cache;
+  } else if (options.immutable) {
+    cacheControl = 'immutable';
+  }
+  options.cacheControl = cacheControl;
 
   return options;
 }

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -12,5 +12,29 @@ describe('#parseCliArgsToOptions()', () => {
     it('should be array if arg is given', () => {
       expect(parseCliArgsToOptions([0, 0, '--gzip', 'js,css,html']).gzip).to.deep.equal(['js', 'css', 'html']);
     });
+
+    it('should accept a --cache argument to set the max-age Cache-Control header', () => {
+      const argv = [0, 0, '--cache', 64];
+      const parsedOptions = parseCliArgsToOptions(argv);
+      expect(parsedOptions.cacheControl).to.equal('max-age=64');
+    });
+
+    it('should accept a --noCache argument to disable caching in the Cache-Control header', () => {
+      const argv = [0, 0, '--noCache', '--otherParam'];
+      const parsedOptions = parseCliArgsToOptions(argv);
+      expect(parsedOptions.cacheControl).to.equal('no-cache, no-store, must-revalidate');
+    });
+
+    it('should accept an --immutable argument to set the immutable Cache-Control header', () => {
+      const argv = [0, 0, '--otherParam', '--immutable'];
+      const parsedOptions = parseCliArgsToOptions(argv);
+      expect(parsedOptions.cacheControl).to.equal('immutable');
+    });
+
+    it('should not accept more than one caching argument', () => {
+      const argv = [0, 0, '--noCache', '--cache', 34];
+      const parsedOptions = parseCliArgsToOptions(argv);
+      expect(parsedOptions.cacheControl).to.equal('no-cache, no-store, must-revalidate');
+    });
   });
 });


### PR DESCRIPTION
I have a need to sometimes break all caching that would be done by services fronting s3 (in our case CloudFront) - some browsers ignore any `max-age` headers and we've found that setting `Cache-Control: no-cache, no-store, must-revalidate` headers is the safest way to absolutely make sure all browsers and CloudFront grab the asset from s3 anew with each request.

I'd love to add the `--no-cache` argument to help facilitate this!