### PR TITLE
Added blanket cache-control header argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This parameter cannot be used with `--cache` or `--immutable` parameters. If tho
 
 Use this parameter to specify an entirely custom Cache-Control header, which will result in `Cache-Control: X`. Use this if you have more complicated cache-control needs.
 
-The `--cacheControl` option supercedes all other cache parameters (`--no-cache`, `--cache`, and `immutable`), which will be ignored.
+The `--cacheControl` option supercedes all other cache parameters (`no-cache`, `cache`, and `immutable`), which will be ignored.
 
 ```
 --etag X

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ Use this parameter to specify `Cache-Control: no-cache, no-store, must-revalidat
 This parameter cannot be used with `--cache` or `--immutable` parameters. If those are used together, only the first one will be taken into account in the order 1) `noCache`, 2) `cache`, 3) `immutable`.
 
 ```
+--cacheControl X
+```
+
+Use this parameter to specify an entirely custom Cache-Control header, which will result in `Cache-Control: X`. Use this if you have more complicated cache-control needs.
+
+The `--cacheControl` option supercedes all other cache parameters (`--no-cache`, `--cache`, and `immutable`), which will be ignored.
+
+```
 --etag X
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "s3-deploy",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -83,16 +83,16 @@ export function parseCliArgsToOptions(processArgv = process.argv) {
   }));
 
   let cacheControl = undefined;
-  if (options.cacheControl) {
-    cacheControl = options.cacheControl;
-  } else if (options.noCache) {
-    cacheControl = 'no-cache, no-store, must-revalidate';
-  } else if (options.hasOwnProperty('cache')) {
-    cacheControl = 'max-age=' + options.cache;
-  } else if (options.immutable) {
-    cacheControl = 'immutable';
+  if (!options.cacheControl) {
+    if (options.noCache) {
+      cacheControl = 'no-cache, no-store, must-revalidate';
+    } else if (options.hasOwnProperty('cache')) {
+      cacheControl = 'max-age=' + options.cache;
+    } else if (options.immutable) {
+      cacheControl = 'immutable';
+    }
+    options.cacheControl = cacheControl;
   }
-  options.cacheControl = cacheControl;
 
   return options;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,10 @@ export function parseCliArgsToOptions(processArgv = process.argv) {
     options.cache = argv.cache;
   }
 
+  if(argv.hasOwnProperty('cacheControl')) {
+    options.cacheControl = argv.cacheControl;
+  }
+
   if(argv.hasOwnProperty('noCache')) {
     options.noCache = true;
   }
@@ -79,7 +83,9 @@ export function parseCliArgsToOptions(processArgv = process.argv) {
   }));
 
   let cacheControl = undefined;
-  if (options.noCache) {
+  if (options.cacheControl) {
+    cacheControl = options.cacheControl;
+  } else if (options.noCache) {
     cacheControl = 'no-cache, no-store, must-revalidate';
   } else if (options.hasOwnProperty('cache')) {
     cacheControl = 'max-age=' + options.cache;

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -31,6 +31,12 @@ describe('#parseCliArgsToOptions()', () => {
       expect(parsedOptions.cacheControl).to.equal('immutable');
     });
 
+    it('should accept a --cacheControl argument to set the Cache-Control header specifically', () => {
+      const argv = [0, 0, '--cacheControl', 'public,max-age=60,s-maxage=3600'];
+      const parsedOptions = parseCliArgsToOptions(argv);
+      expect(parsedOptions.cacheControl).to.equal('public,max-age=60,s-maxage=3600');
+    });
+
     it('should not accept more than one caching argument', () => {
       const argv = [0, 0, '--noCache', '--cache', 34];
       const parsedOptions = parseCliArgsToOptions(argv);


### PR DESCRIPTION
This gives s3-deploy the ability to set a completely custom Cache-Control header, `--cacheControl`, in case you need something more complex (like `s-maxage` settings for a CDN). The `cacheControl` option overrides all other cache options if it is present.