### PR TITLE
[S3-SSE] Allow users to provide an option to enable object SSE.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ You can specify a specific AWS profile to use to connect to S3 (defaults to `def
 Use this parameter to specify that objects being uploaded will be stored with private ACL (Owner gets FULL_CONTROL. No one else has access rights). By default, 'public-read' ACL is set. More information on the canned-acl is available in the [AWS docs](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl)
 
 ```
+--sse [AES256|aws:kms]
+```
+
+Use this parameter to specify Server-Side Encryption options for s3 objects. By default, no SSE is enabled. Optional values `AES256` | `aws:kms`. More information on how to setup AWS profiles is available in the [AWS docs](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html).
+
+
+```
 --ext
 ```
 

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -256,6 +256,9 @@ export const deploy = co.wrap(function *(options) {
   if (options.private) {
     s3UploadOptions.ACL = 'private';
   }
+  if (options.sse) {
+    s3UploadOptions.ServerSideEncryption = options.sse;
+  }
 
   yield Promise.all(options.globbedFiles.map(function (filePath) {
     return handleFile(filePath, s3Client, s3UploadOptions, options);

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,10 @@ export function parseCliArgsToOptions(processArgv = process.argv) {
     options.etag = argv.etag;
   }
 
+  if(argv.hasOwnProperty('sse')) {
+    options.sse = argv.sse;
+  }
+
   if(argv.hasOwnProperty('private')) {
     options.private = true;
   }


### PR DESCRIPTION
Simply accepting `--sse` option to pass along to s3 upload calls.